### PR TITLE
Refactor/divers

### DIFF
--- a/src/app/dashboard/(registre-securite)/interventions/[interventionId]/_components/ReportDialog.tsx
+++ b/src/app/dashboard/(registre-securite)/interventions/[interventionId]/_components/ReportDialog.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+
+import { equipmentService } from '@/services/equipmentService';
+import { EquipmentType } from '@/types/equipment';
 import { CreateReportDto, Organization, OrganizationType, ReportType } from '@/types/intervention';
 import {
   Add as AddIcon,
@@ -69,10 +72,28 @@ const ReportDialog: React.FC<ReportDialogProps> = ({
     typologyCode: '',
     interventionId: interventionId,
     partIds: [],
-    fileIds: []
+    fileIds: [],
+    equipmentIds: []
   });
 
   const [loading, setLoading] = React.useState(false);
+  const [equipmentTypes, setEquipmentTypes] = React.useState<EquipmentType[]>([]);
+
+  // Load equipment types when dialog opens
+  React.useEffect(() => {
+    if (open) {
+      loadEquipmentTypes();
+    }
+  }, [open]);
+
+  const loadEquipmentTypes = async () => {
+    try {
+      const result = await equipmentService.getTypes();
+      setEquipmentTypes(result.results);
+    } catch (error) {
+      console.error('Erreur lors du chargement des types d\'équipements:', error);
+    }
+  };
 
   // Reset form when dialog opens
   React.useEffect(() => {
@@ -84,7 +105,8 @@ const ReportDialog: React.FC<ReportDialogProps> = ({
         typologyCode: '',
         interventionId: interventionId,
         partIds: [],
-        fileIds: []
+        fileIds: [],
+        equipmentIds: []
       });
     }
   }, [open, interventionId]);
@@ -134,6 +156,50 @@ const ReportDialog: React.FC<ReportDialogProps> = ({
             variant="outlined"
             placeholder="Entrez le libellé du rapport..."
             disabled={loading}
+          />
+
+          <Autocomplete
+            multiple
+            options={equipmentTypes || []}
+            getOptionLabel={(option: EquipmentType) => `${option.title} (${option.family?.name})`}
+            value={equipmentTypes?.filter(type => formData.equipmentIds?.includes(Number(type.id))) || []}
+            onChange={(_, newValue) => {
+              const equipmentIds = newValue.map((type: EquipmentType) => Number(type.id));
+              handleFieldChange('equipmentIds', equipmentIds);
+            }}
+            disabled={loading}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Types d'équipements"
+                variant="outlined"
+                placeholder="Sélectionner les types d'équipements..."
+              />
+            )}
+            renderValue={(value, getTagProps) =>
+              value.map((option, index) => (
+                <Chip
+                  {...getTagProps({ index })}
+                  key={option.id}
+                  label={`${option.title}`}
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                />
+              ))
+            }
+            renderOption={(props: any, option: EquipmentType) => (
+              <Box component="li" {...props}>
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                    {option.title}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {option.family?.name}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
           />
 
           <Autocomplete<ReportType>

--- a/src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsx
+++ b/src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import SearchFilters from '@/components/dashboard/SearchFilters';
+import { equipmentService } from '@/services/equipmentService';
 import organizationService from '@/services/organizationService';
 import reportService from '@/services/reportService';
 import reportTypeService from '@/services/reportTypeService';
+import { EquipmentType } from '@/types/equipment';
 import { CreateReportDto, Organization, OrganizationType, Report, ReportType, UpdateReportDto } from '@/types/intervention';
 import { Typologies } from '@/types/site';
 import {
@@ -86,6 +88,7 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
   // Data states
   const [reports, setReports] = useState<Report[]>([]);
   const [reportTypes, setReportTypes] = useState<ReportType[]>([]);
+  const [equipmentTypes, setEquipmentTypes] = useState<EquipmentType[]>([]);
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [filteredReports, setFilteredReports] = useState<Report[]>([]);
@@ -102,7 +105,8 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
     label: '',
     typeCode: '',
     organizationId: 0,
-    typologyCode: ''
+    typologyCode: '',
+    equipmentIds: []
   });
 
   // Filters state
@@ -130,7 +134,7 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
   const loadData = async () => {
     try {
       setLoading(true);
-      await Promise.all([loadReports(), loadReferenceData()]);
+      await Promise.all([loadReports(), loadReferenceData(), loadEquipmentTypes()]);
     } finally {
       setLoading(false);
     }
@@ -146,6 +150,16 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
     } catch (error) {
       console.error('Erreur lors du chargement des rapports:', error);
       onNotification('Erreur lors du chargement des rapports', 'error');
+    }
+  };
+
+  const loadEquipmentTypes = async () => {
+    try {
+      const result = await equipmentService.getTypes();
+      setEquipmentTypes(result.results);
+    } catch (error) {
+      console.error('Erreur lors du chargement des types d\'équipements:', error);
+      onNotification('Erreur lors du chargement des types d\'équipements', 'error');
     }
   };
 
@@ -232,7 +246,8 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
         label: report.label,
         typeCode: report.type.code,
         organizationId: report.organization.id,
-        typologyCode: report.typology.code
+        typologyCode: report.typology.code,
+        equipmentIds: report.equipments?.map(equipment => equipment.equipmentId) || []
       });
     }
   };
@@ -456,6 +471,7 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
                 <TableHead>
                   <TableRow>
                     <TableCell>Libellé</TableCell>
+                    <TableCell>Type d&apos;équipements</TableCell>
                     <TableCell>Type</TableCell>
                     <TableCell>Organisation</TableCell>
                     <TableCell>Typologie</TableCell>
@@ -499,6 +515,11 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
                                 {report.label}
                               </Typography>
                             </Box>
+                          </TableCell>
+                          <TableCell>
+                            <Typography variant="body2">
+                              {report.equipments?.map(equipment => equipment.equipmentType.title).join(', ')}
+                            </Typography>
                           </TableCell>
                           <TableCell>
                             <Typography variant="body2">
@@ -661,6 +682,39 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
                                           variant="outlined"
                                           size="small"
                                         />
+
+                                        <Autocomplete
+                                          multiple
+                                          options={equipmentTypes || []}
+                                          getOptionLabel={(option: EquipmentType) => `${option.title} (${option.serialNumber})`}
+                                          value={equipmentTypes?.filter(type => editForm.equipmentIds?.includes(Number(type.id))) || []}
+                                          onChange={(_, newValue) => {
+                                            const equipmentIds = newValue.map((type: EquipmentType) => Number(type.id));
+                                            setEditForm(f => ({ ...f, equipmentIds }));
+                                          }}
+                                          renderInput={(params) => (
+                                            <TextField
+                                              {...params}
+                                              label="Types d'équipements"
+                                              size="small"
+                                              variant="outlined"
+                                              placeholder="Sélectionner les types d'équipements..."
+                                            />
+                                          )}
+                                          renderValue={(value, getTagProps) =>
+                                            value.map((option, index) => (
+                                              <Chip
+                                                {...getTagProps({ index })}
+                                                key={option.id}
+                                                label={`${option.title} (${option.serialNumber})`}
+                                                size="small"
+                                                color="primary"
+                                                variant="outlined"
+                                              />
+                                            ))
+                                          }
+                                        />
+
                                         <Autocomplete<ReportType>
                                           options={reportTypes || []}
                                           getOptionLabel={(option: ReportType) => `${option.name} (${option.code})`}

--- a/src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsx
+++ b/src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsx
@@ -713,6 +713,18 @@ const ReportsTab: React.FC<ReportsTabProps> = ({ interventionId, onNotification,
                                               />
                                             ))
                                           }
+                                          renderOption={(props: any, option: EquipmentType) => (
+                                            <Box component="li" {...props}>
+                                              <Box>
+                                                <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                                                  {option.title}
+                                                </Typography>
+                                                <Typography variant="caption" color="text.secondary">
+                                                  {option.family?.name}
+                                                </Typography>
+                                              </Box>
+                                            </Box>
+                                          )}
                                         />
 
                                         <Autocomplete<ReportType>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
           <Box
             component="main"
             sx={{
-              px: { xs: 2, md: 6 },
+              px: { xs: 2, md: 3 },
               pt: '30px',
               pb: { xs: 2, sm: 2, md: 3 },
               flex: 1,

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -3,6 +3,7 @@ import { UserRoleType } from '@/types/auth';
 import { AdminPanelSettings } from '@mui/icons-material';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import AppsIcon from '@mui/icons-material/Apps';
+import ArticleIcon from '@mui/icons-material/Article';
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import BuildIcon from '@mui/icons-material/Build';
 import BusinessIcon from '@mui/icons-material/Business';
@@ -11,6 +12,7 @@ import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
 import DescriptionIcon from '@mui/icons-material/Description';
 import FolderIcon from '@mui/icons-material/Folder';
 import GroupIcon from '@mui/icons-material/Group';
+import InventoryIcon from '@mui/icons-material/Inventory';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import MenuIcon from '@mui/icons-material/Menu';
 import PeopleIcon from '@mui/icons-material/People';
@@ -18,8 +20,6 @@ import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import ShoppingCartRoundedIcon from '@mui/icons-material/ShoppingCartRounded';
 import StorageIcon from '@mui/icons-material/Storage';
 import SupportRoundedIcon from '@mui/icons-material/SupportRounded';
-import InventoryIcon from '@mui/icons-material/Inventory';
-import ArticleIcon from '@mui/icons-material/Article';
 import {
   Box,
   Chip,
@@ -212,7 +212,7 @@ export default function Sidebar() {
   const handleSitesClick = () => {
     setOpenSites(!openSites);
   };
-  
+
   const handleEquipmentsClick = () => {
     setOpenEquipments(!openEquipments);
   };
@@ -339,7 +339,7 @@ export default function Sidebar() {
 
             {/* Sous-menu Équipements */}
             <Collapse in={openEquipments} timeout={400} unmountOnExit>
-              <Box sx={{ pl: 4, py: 1 }}>
+              <Box sx={{ pl: 2, py: 1 }}>
                 <Link href="/dashboard/domaines" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}
@@ -351,7 +351,7 @@ export default function Sidebar() {
                     </Typography>
                   </StyledListItemButton>
                 </Link>
-                
+
                 <Link href="/dashboard/familles" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}
@@ -363,7 +363,7 @@ export default function Sidebar() {
                     </Typography>
                   </StyledListItemButton>
                 </Link>
-                
+
                 <Link href="/dashboard/types" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}
@@ -375,7 +375,7 @@ export default function Sidebar() {
                     </Typography>
                   </StyledListItemButton>
                 </Link>
-                
+
                 <Link href="/dashboard/compatibilite" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}
@@ -439,7 +439,7 @@ export default function Sidebar() {
 
             {/* Sous-menu Produits */}
             <Collapse in={openProducts} timeout={400} unmountOnExit>
-              <Box sx={{ pl: 4, py: 1 }}>
+              <Box sx={{ pl: 2, py: 1 }}>
                 <Link href="/dashboard/produits" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}
@@ -517,7 +517,7 @@ export default function Sidebar() {
 
             {/* Sous-menu Sites */}
             <Collapse in={openSites} timeout={400} unmountOnExit>
-              <Box sx={{ pl: 4, py: 1 }}>
+              <Box sx={{ pl: 2, py: 1 }}>
                 <Link href="/dashboard/sites" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}
@@ -572,7 +572,7 @@ export default function Sidebar() {
 
             {/* Sous-menu Interventions */}
             <Collapse in={openInterventions} timeout={400} unmountOnExit>
-              <Box sx={{ pl: 4, py: 1 }}>
+              <Box sx={{ pl: 2, py: 1 }}>
                 <Link href="/dashboard/interventions" style={{ textDecoration: 'none', color: 'inherit' }}>
                   <StyledListItemButton
                     sx={{ py: 0.75, mb: 0.5, width: '100%' }}

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,6 +1,5 @@
 import { api } from '@/lib/api';
 import { CreateReportDto, Report, UpdateReportDto } from '@/types/intervention';
-import { equipmentService } from './equipmentService';
 
 export const reportService = {
   async getReports(params: {
@@ -59,31 +58,6 @@ export const reportService = {
   async getReport(id: number): Promise<Report> {
     const response = await api.get<Report>(`/reports/${id}`);
     const report = response.data;
-
-    // Récupérer les détails des types d'équipements si equipments existe
-    if (report.equipments && report.equipments.length > 0) {
-      try {
-        const equipmentTypePromises = report.equipments.map(async (equipment) => {
-          try {
-            const equipmentTypeResponse = await equipmentService.getTypeById(equipment.equipmentId.toString());
-            return equipmentTypeResponse.data;
-          } catch (error) {
-            console.error(`Erreur lors de la récupération du type d'équipement ${equipment.equipmentId}:`, error);
-            return null;
-          }
-        });
-
-        const equipmentTypes = await Promise.all(equipmentTypePromises);
-        // Filtrer les types null (en cas d'erreur)
-        report.equipmentTypes = equipmentTypes.filter(type => type !== null);
-      } catch (error) {
-        console.error('Erreur lors de la récupération des types d\'équipements:', error);
-        report.equipmentTypes = [];
-      }
-    } else {
-      report.equipmentTypes = [];
-    }
-
     return report;
   },
 

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,5 +1,6 @@
 import { api } from '@/lib/api';
 import { CreateReportDto, Report, UpdateReportDto } from '@/types/intervention';
+import { equipmentService } from './equipmentService';
 
 export const reportService = {
   async getReports(params: {
@@ -57,7 +58,33 @@ export const reportService = {
 
   async getReport(id: number): Promise<Report> {
     const response = await api.get<Report>(`/reports/${id}`);
-    return response.data;
+    const report = response.data;
+
+    // Récupérer les détails des types d'équipements si equipments existe
+    if (report.equipments && report.equipments.length > 0) {
+      try {
+        const equipmentTypePromises = report.equipments.map(async (equipment) => {
+          try {
+            const equipmentTypeResponse = await equipmentService.getTypeById(equipment.equipmentId.toString());
+            return equipmentTypeResponse.data;
+          } catch (error) {
+            console.error(`Erreur lors de la récupération du type d'équipement ${equipment.equipmentId}:`, error);
+            return null;
+          }
+        });
+
+        const equipmentTypes = await Promise.all(equipmentTypePromises);
+        // Filtrer les types null (en cas d'erreur)
+        report.equipmentTypes = equipmentTypes.filter(type => type !== null);
+      } catch (error) {
+        console.error('Erreur lors de la récupération des types d\'équipements:', error);
+        report.equipmentTypes = [];
+      }
+    } else {
+      report.equipmentTypes = [];
+    }
+
+    return report;
   },
 
   async createReport(data: CreateReportDto): Promise<Report> {

--- a/src/types/intervention.ts
+++ b/src/types/intervention.ts
@@ -6,6 +6,7 @@
 // ============================================================================
 
 import { User } from "./auth";
+import { EquipmentType } from "./equipment";
 import { Part, Typologies } from "./site";
 
 // =========================
@@ -105,6 +106,11 @@ export interface UpdateReportTypeDto {
   periodicity?: Periodicity;
 }
 
+export interface ReportEquipmentType {
+  id: number;
+  equipmentId: number; // Equivaut à l'id de EquipmentType
+}
+
 export interface Report {
   id: number;
   createdAt: string;
@@ -118,6 +124,8 @@ export interface Report {
   parts?: Part[];
   files?: File[];
   obsevations?: Observations[];
+  equipments?: ReportEquipmentType[];
+  equipmentTypes?: EquipmentType[];
 }
 
 export interface CreateReportDto {
@@ -128,6 +136,7 @@ export interface CreateReportDto {
   interventionId: number;
   partIds: number[];
   fileIds: number[];
+  equipmentIds?: number[];
 }
 
 export interface UpdateReportDto {
@@ -138,6 +147,7 @@ export interface UpdateReportDto {
   interventionId?: number;
   partIds?: number[];
   fileIds?: number[];
+  equipmentIds?: number[];
 }
 
 // =========================

--- a/src/types/intervention.ts
+++ b/src/types/intervention.ts
@@ -108,7 +108,8 @@ export interface UpdateReportTypeDto {
 
 export interface ReportEquipmentType {
   id: number;
-  equipmentId: number; // Equivaut à l'id de EquipmentType
+  equipmentId: number;
+  equipmentType: EquipmentType;
 }
 
 export interface Report {
@@ -125,7 +126,6 @@ export interface Report {
   files?: File[];
   obsevations?: Observations[];
   equipments?: ReportEquipmentType[];
-  equipmentTypes?: EquipmentType[];
 }
 
 export interface CreateReportDto {


### PR DESCRIPTION
This pull request introduces the ability to associate equipment types with reports in the intervention dashboard. It includes updates to the UI, data models, and services to support this feature. Additionally, there are minor UI adjustments to improve layout consistency.

### Feature: Equipment Type Integration with Reports
* Added the `equipmentIds` field to the report form state in `ReportDialog` and `ReportsTab`, allowing users to associate equipment types with reports. ([src/app/dashboard/(registre-securite)/interventions/[interventionId]/_components/ReportDialog.tsxL72-R96](diffhunk://#diff-2154ed5f5c6b8f4c0921930052baaf0dc60c052447fb991239e19b380388b8ddL72-R96), [src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsxL105-R109](diffhunk://#diff-b41a92ae2b6c7c18117fe42729949233bccd3d3863256b0377b685357a752913L105-R109))
* Implemented an `Autocomplete` component in `ReportDialog` and `ReportsTab` for selecting multiple equipment types, with options dynamically loaded from the `equipmentService`. ([src/app/dashboard/(registre-securite)/interventions/[interventionId]/_components/ReportDialog.tsxR161-R204](diffhunk://#diff-2154ed5f5c6b8f4c0921930052baaf0dc60c052447fb991239e19b380388b8ddR161-R204), [src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsxR685-R729](diffhunk://#diff-b41a92ae2b6c7c18117fe42729949233bccd3d3863256b0377b685357a752913R685-R729))
* Updated the `ReportsTab` table to display associated equipment types for each report. ([src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsxR474](diffhunk://#diff-b41a92ae2b6c7c18117fe42729949233bccd3d3863256b0377b685357a752913R474), [src/app/dashboard/(registre-securite)/interventions/[interventionId]/reports/ReportsTab.tsxR519-R523](diffhunk://#diff-b41a92ae2b6c7c18117fe42729949233bccd3d3863256b0377b685357a752913R519-R523))

### Backend and Data Model Changes
* Introduced a new `ReportEquipmentType` interface and added an `equipments` field to the `Report` model to represent associated equipment types. [[1]](diffhunk://#diff-e61a28029f49ae6dfb89b7996cd1dbc95a43f03e0b3c3c19d869fbea54c02343R109-R114) [[2]](diffhunk://#diff-e61a28029f49ae6dfb89b7996cd1dbc95a43f03e0b3c3c19d869fbea54c02343R128)
* Extended `CreateReportDto` and `UpdateReportDto` to include the `equipmentIds` field for API compatibility. [[1]](diffhunk://#diff-e61a28029f49ae6dfb89b7996cd1dbc95a43f03e0b3c3c19d869fbea54c02343R139) [[2]](diffhunk://#diff-e61a28029f49ae6dfb89b7996cd1dbc95a43f03e0b3c3c19d869fbea54c02343R150)
* Updated `reportService` to ensure compatibility with the new data structure.

### UI and Layout Adjustments
* Adjusted padding in `Sidebar` submenus for better alignment. [[1]](diffhunk://#diff-fcb51eda3cd79f543f100dd64d2b608aa4b248c2fab95de9e1856e4f847fe779L342-R342) [[2]](diffhunk://#diff-fcb51eda3cd79f543f100dd64d2b608aa4b248c2fab95de9e1856e4f847fe779L442-R442) [[3]](diffhunk://#diff-fcb51eda3cd79f543f100dd64d2b608aa4b248c2fab95de9e1856e4f847fe779L520-R520) [[4]](diffhunk://#diff-fcb51eda3cd79f543f100dd64d2b608aa4b248c2fab95de9e1856e4f847fe779L575-R575)
* Reduced horizontal padding in the main layout to improve spacing on medium screens.